### PR TITLE
ci: renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,6 @@
 {
     "extends": [
+      "github>indykite/.github//.github/renovate.json5",
       "config:base",
       "schedule:weekly",
       ":disableDependencyDashboard"


### PR DESCRIPTION
## Description of change
Prepend the org shared renovate config (public-repo variant, github>indykite/.github) to this repo's existing standalone renovate.json, keeping its custom overrides.