### PR TITLE
ci: remove duplicate config:base renovate preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,6 @@
 {
     "extends": [
-      "github>indykite/.github//.github/renovate.json5",
-      "schedule:weekly",
-      ":disableDependencyDashboard"
+      "github>indykite/.github//.github/renovate.json5"
     ],
     "semanticCommits": "disabled",
     "commitMessagePrefix": "chore(deps): ",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,6 @@
 {
     "extends": [
       "github>indykite/.github//.github/renovate.json5",
-      "config:base",
       "schedule:weekly",
       ":disableDependencyDashboard"
     ],


### PR DESCRIPTION
## Description of change
config:base is already part of the org shared renovate config (github>indykite/.github), so it's dropped here to avoid duplication and the deprecated-preset migration warning (#14).